### PR TITLE
Fix bug 1193696

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
@@ -72,7 +72,7 @@ You will need one or more vouchers. The <a href="{{ policy }}">Commit Access Pol
   <li>{% trans rheeet='https://ftp.mozilla.org/pub/mozilla.org/mozilla/libraries/bonus-tracks/rheet.wav' %}
     Need to hear a <a href="{{ rheeet }}">rheeet</a>?
   {% endtrans %}</li>
-  <li>{% trans mercurial='https://developer.mozilla.org/Mercurial_FAQ#How_do_I_check_stuff_in.3F' %}
+  <li>{% trans mercurial='https://developer.mozilla.org/docs/Mercurial/Using_Mercurial#How_do_I_check_stuff_in.3F' %}
     We have a document on <a href="{{ mercurial }}">checking in using Hg</a>.
   {% endtrans %}</li>
 </ul>


### PR DESCRIPTION
Correct the URL for the link to information about checking in using Mercurial so that it's no longer a 404 in some locales.
